### PR TITLE
Perl 5.6.x support

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Dist-CheckConflicts
 
 {{$NEXT}}
+      - support Perl 5.6.x (Toby Inkster)
 
 0.08  2013-07-09
       - remove Test::Warnings dep

--- a/lib/Dist/CheckConflicts.pm
+++ b/lib/Dist/CheckConflicts.pm
@@ -1,7 +1,7 @@
 package Dist::CheckConflicts;
 use strict;
 use warnings;
-use 5.008001;
+use 5.006;
 # ABSTRACT: declare version conflicts for your dist
 
 use base 'Exporter';
@@ -173,16 +173,16 @@ sub import {
 }
 
 sub _strip_opt {
-    my $opt = shift;
-    my $idx = first_index { ( $_ || '' ) eq $opt } @_;
+    my ($opt, @args) = @_;
+    my $idx = first_index { ( $_ || '' ) eq $opt } @args;
 
-    return ( undef, @_ ) unless $idx >= 0 && $#_ >= $idx + 1;
+    return ( undef, @args ) unless $idx >= 0 && $#args >= $idx + 1;
 
-    my $val = $_[ $idx + 1 ];
+    my $val = $args[ $idx + 1 ];
 
-    splice @_, $idx, 2;
+    splice @args, $idx, 2;
 
-    return ( $val, @_ );
+    return ( $val, @args );
 }
 
 sub _check_version {


### PR DESCRIPTION
This pull request _appears_ to get things working for Perl 5.6.x.

My testing has been a little limited as I am lacking a working CPAN client for 5.6, so have been resorting to copying ".pm" files from my 5.18.x installation.

The Makefile.PL in the current release of Dist-CheckConflicts includes `use 5.008001`; I'm not sure of the details of how Dist::Zilla generates that file, but something may need changing there too.
